### PR TITLE
Bump aiohwenergy to 0.8.0 to make it compatible for 2022.2

### DIFF
--- a/custom_components/homewizard_energy/__init__.py
+++ b/custom_components/homewizard_energy/__init__.py
@@ -8,6 +8,7 @@ import async_timeout
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import CONF_API, COORDINATOR, DOMAIN, PLATFORMS
 from .coordinator import HWEnergyDeviceUpdateCoordinator as Coordinator
@@ -21,7 +22,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     _LOGGER.debug("__init__ async_setup_entry")
 
     # Get api and do a initialization
-    energy_api = aiohwenergy.HomeWizardEnergy(entry.data.get("host"))
+    session = async_get_clientsession(hass)
+    energy_api = aiohwenergy.HomeWizardEnergy(
+        entry.data.get("host"), clientsession=session
+    )
 
     # Validate connection
     initialized = False

--- a/custom_components/homewizard_energy/manifest.json
+++ b/custom_components/homewizard_energy/manifest.json
@@ -1,21 +1,12 @@
 {
-  "domain": "homewizard_energy",
-  "name": "HomeWizard Energy",
-  "version": "0.0.0",
-  "documentation": "https://github.com/DCSBL/ha-homewizard-energy",
-  "issue_tracker": "https://github.com/DCSBL/ha-homewizard-energy/issues",
-  "codeowners": [
-    "@DCSBL"
-  ],
-  "dependencies": [
-    "zeroconf"
-  ],
-  "requirements": [
-    "aiohwenergy==0.4.0"
-  ],
-  "zeroconf": [
-    "_hwenergy._tcp.local."
-  ],
+  "codeowners": ["@DCSBL"],
   "config_flow": true,
-  "iot_class": "local_polling"
+  "documentation": "https://github.com/DCSBL/ha-homewizard-energy",
+  "domain": "homewizard_energy",
+  "iot_class": "local_polling",
+  "issue_tracker": "https://github.com/DCSBL/ha-homewizard-energy/issues",
+  "name": "HomeWizard Energy",
+  "requirements": ["aiohwenergy==0.8.0"],
+  "version": "0.0.0",
+  "zeroconf": ["_hwenergy._tcp.local."]
 }


### PR DESCRIPTION
Home Assitant core uses 0.8.0, this integration used 0.4.0 which was incompatible. This bump should fix that so the core and custom version can be used together.